### PR TITLE
Cmd support environment variables

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -3,7 +3,7 @@
 case "$1" in
   pre_machine)
     # ensure correct level of parallelism
-    expected_nodes=5
+    expected_nodes=4
     if [ "$CIRCLE_NODE_TOTAL" -ne "$expected_nodes" ]
     then
         echo "Parallelism is set to ${CIRCLE_NODE_TOTAL}x, but we need ${expected_nodes}x."

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -21,6 +21,21 @@
 
 package com.spotify.helios.agent;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Arrays.asList;
+
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -43,19 +58,6 @@ import com.spotify.helios.common.descriptors.ServicePortParameters;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.common.descriptors.TcpHealthCheck;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.security.SecureRandom;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.regex.Pattern;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Arrays.asList;
 
 /**
  * Provides docker container configuration for running a task.
@@ -108,10 +110,21 @@ public class TaskConfig {
    * @return The ContainerConfig object.
    */
   public ContainerConfig containerConfig(final ImageInfo imageInfo) {
+    return containerConfig(imageInfo, containerEnv());
+  }
+
+  /**
+   * Create docker container configuration for a job.
+   * @param imageInfo The ImageInfo object.
+   * @param properties Properties to resolve against.
+   * @return The ContainerConfig object.
+   */
+  public ContainerConfig containerConfig(final ImageInfo imageInfo,
+                                         final Map<String, String> properties) {
     final ContainerConfig.Builder builder = ContainerConfig.builder();
 
     builder.image(job.getImage());
-    builder.cmd(job.getCommand());
+    builder.cmd(containerCmdStrings(properties));
     builder.env(containerEnvStrings());
     builder.exposedPorts(containerExposedPorts());
     builder.volumes(volumes());
@@ -258,11 +271,23 @@ public class TaskConfig {
    */
   private List<String> containerEnvStrings() {
     final Map<String, String> env = containerEnv();
-    final List<String> envList = Lists.newArrayList();
+    final List<String> envList = Lists.newArrayListWithCapacity(env.entrySet().size());
     for (final Map.Entry<String, String> entry : env.entrySet()) {
       envList.add(entry.getKey() + '=' + entry.getValue());
     }
     return envList;
+  }
+
+  /**
+   * Compute docker container cmd arguments and resolve them against the hosts environment.
+   * @return The container cmd arguments.
+   */
+  private List<String> containerCmdStrings(final Map<String, String> properties) {
+    final List<String> list = Lists.newArrayListWithCapacity(job.getCommand().size());
+    for (String value : job.getCommand()) {
+      list.add(StrSubstitutor.replace(value, properties));
+    }
+    return list;
   }
 
   /**


### PR DESCRIPTION
Let _cmd_ resolve against environment variables, esp. nice if you've got an _entrypoint_ and would like to pass in host-specific values.
